### PR TITLE
feat: Terraform 인프라 구성 및 GCP 서버 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,5 @@ settings.json
 *.pid.lock
 
 data/test_audio
+# BFG Repo-Cleaner reports
+..bfg-report/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,46 +1,80 @@
 version: "3.8"
 
 services:
-  gaon_backend:
-    image: ${BACKEND_IMAGE:-asia-northeast3-docker.pkg.dev/gaon-477004/gaon-docker-hub/backend:latest}
-    container_name: gaon-backend
-    env_file:
-      - .env
+  postgres:
+    image: pgvector/pgvector:pg17
+    container_name: gaon-postgres
     environment:
-      - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}
-      - DB_HOST=localhost
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_SHARED_PRELOAD_LIBRARIES: pg_stat_statements
+      POSTGRES_MAX_CONNECTIONS: 100
+      POSTGRES_SHARED_BUFFERS: 256MB
+      POSTGRES_EFFECTIVE_CACHE_SIZE: 1GB
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - gaon_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  backend:
+    image: asia-northeast3-docker.pkg.dev/gaon-477004/gaon-docker-hub/backend:latest
+    container_name: gaon-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}
+      - DB_HOST=postgres
       - DB_PORT=5432
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_NAME=${DB_NAME}
-      - SECRET_KEY=${SECRET_KEY}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - FRONTEND_URL=${FRONTEND_URL}
-      - GOOGLE_APPLICATION_CREDENTIALS=/app/gcp-key.json
     volumes:
       - ./logs:/app/logs
-      - ./gcp_service_account_key.json:/app/gcp-key.json:ro
+    networks:
+      - gaon_network
     restart: unless-stopped
-    network_mode: host
 
-  gaon_frontend:
-    image: ${FRONTEND_IMAGE:-asia-northeast3-docker.pkg.dev/gaon-477004/gaon-docker-hub/frontend:latest}
+  frontend:
+    image: asia-northeast3-docker.pkg.dev/gaon-477004/gaon-docker-hub/frontend:latest
     container_name: gaon-frontend
-    environment:
-      - NEXT_PUBLIC_API_URL=""
     depends_on:
-      - gaon_backend
+      - backend
+    networks:
+      - gaon_network
     restart: unless-stopped
-    network_mode: host
 
   nginx:
     image: nginx:alpine
     container_name: gaon-nginx
+    ports:
+      - "80:80"
+      - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
-      - gaon_frontend
-      - gaon_backend
+      - backend
+      - frontend
+    networks:
+      - gaon_network
     restart: unless-stopped
-    network_mode: host
+
+networks:
+  gaon_network:
+    driver: bridge
+
+volumes:
+  postgres_data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,31 +3,21 @@ events {
 }
 
 http {
+    # 파일 업로드 크기 제한 (50MB)
+    client_max_body_size 50M;
+    
     upstream frontend {
-        server 127.0.1.1:3000;
+        server gaon-frontend:3000;
     }
     
     upstream backend {
-        server 127.0.0.1:8000;
+        server gaon-backend:8000;
     }
 
-    # HTTP to HTTPS redirect
+    # HTTP server
     server {
         listen 80;
-        server_name xn--o39a190c.site www.xn--o39a190c.site 가온.site www.가온.site;
-        return 301 https://$server_name$request_uri;
-    }
-
-    # HTTPS server
-    server {
-        listen 443 ssl http2;
-        server_name xn--o39a190c.site www.xn--o39a190c.site 가온.site www.가온.site;
-
-        ssl_certificate /etc/letsencrypt/live/xn--o39a190c.site/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/xn--o39a190c.site/privkey.pem;
-        
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+        server_name _;
 
         # Frontend routes
         location / {
@@ -35,7 +25,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # Backend API routes
@@ -44,7 +34,12 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # 타임아웃 설정 (분석 파이프라인 대응)
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         # Health check

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,33 @@
+# Terraform state files
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+
+# Terraform variable files with sensitive data
+*.tfvars
+*.tfvars.json
+
+# Terraform CLI configuration
+.terraformrc
+terraform.rc
+
+# Terraform directory
+.terraform/
+.terraform.lock.hcl
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# SSH keys
+*.pem
+*.key
+
+# GCP credentials
+*service_account*.json

--- a/terraform/IMPORT.md
+++ b/terraform/IMPORT.md
@@ -1,0 +1,55 @@
+# 기존 GCP 리소스 Import 가이드
+
+기존에 생성된 GCP 리소스를 Terraform으로 관리하기 위해 import합니다.
+
+## Import 명령어
+
+```bash
+# 1. Storage Bucket
+terraform import google_storage_bucket.gaon_data gaon-cloud-data
+
+# 2. Artifact Registry
+terraform import google_artifact_registry_repository.gaon_docker projects/gaon-477004/locations/asia-northeast3/repositories/gaon-docker-hub
+
+# 3. Pub/Sub Topic
+terraform import google_pubsub_topic.gcs_rag_notifications projects/gaon-477004/topics/gcs-rag-notifications
+
+# 4. Cloud Function - RAG Processor
+terraform import google_cloudfunctions2_function.rag_processor projects/gaon-477004/locations/asia-northeast3/functions/rag-processor
+
+# 5. Cloud Function - TOC Processor
+terraform import google_cloudfunctions2_function.toc_pdf_processor projects/gaon-477004/locations/asia-northeast3/functions/toc-pdf-processor
+```
+
+## Import 순서
+
+1. **먼저 plan 실행**
+   ```bash
+   terraform plan
+   ```
+
+2. **리소스가 생성되려고 하면 import**
+   ```bash
+   # 위의 import 명령어 실행
+   ```
+
+3. **다시 plan으로 확인**
+   ```bash
+   terraform plan
+   # No changes 또는 최소한의 변경만 있어야 함
+   ```
+
+## 주의사항
+
+- Cloud Functions의 소스 코드는 별도로 관리됩니다
+- Import 후에도 소스 코드 배포는 기존 방식 유지
+- Terraform은 인프라 구조만 관리합니다
+
+## 선택적 관리
+
+모든 리소스를 Terraform으로 관리하지 않아도 됩니다:
+
+- **Terraform 관리 권장**: VM, 방화벽, Storage Bucket, Artifact Registry
+- **수동 관리 가능**: Cloud Functions (코드 변경이 잦은 경우)
+
+수동 관리를 원하면 `gcp_resources.tf`에서 해당 리소스를 주석 처리하세요.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,121 @@
+# GAON GCP Infrastructure
+
+Terraform으로 GCP 인프라를 프로비저닝합니다.
+
+## 관리되는 리소스
+
+### 컴퓨팅
+- **VM 인스턴스**: gaon-backend-server (e2-medium)
+- **방화벽 규칙**: HTTP (80), HTTPS (443), Backend API (8000), SSH (22)
+
+### 스토리지 & 레지스트리
+- **Cloud Storage**: gaon-cloud-data (ASIA)
+- **Artifact Registry**: gaon-docker-hub (Docker)
+
+### 서버리스
+- **Cloud Functions**:
+  - rag-processor (Python 3.11)
+  - toc-pdf-processor (Python 3.11)
+- **Pub/Sub**: gcs-rag-notifications
+
+### 기타
+- **SSH 키**: `~/.ssh/gaon_ver2.key`
+
+## 사전 요구사항
+
+- Terraform 설치
+- GCP 서비스 계정 키: `backend/gcp_service_account_key.json`
+
+## 사용 방법
+
+### 1. 초기화
+
+```bash
+cd terraform
+terraform init
+```
+
+### 2. DB 설정 로드 (backend/.env 사용)
+
+```bash
+# Python config에서 DB 설정 읽기
+eval $(python3 get_db_config.py)
+```
+
+### 3. 기존 리소스 Import (최초 1회만)
+
+기존에 생성된 리소스를 Terraform으로 관리하려면:
+
+```bash
+# IMPORT.md 파일 참조
+terraform import google_storage_bucket.gaon_data gaon-cloud-data
+terraform import google_artifact_registry_repository.gaon_docker projects/gaon-477004/locations/asia-northeast3/repositories/gaon-docker-hub
+# ... (나머지는 IMPORT.md 참조)
+```
+
+### 3. 계획 확인
+
+```bash
+terraform plan
+```
+
+### 4. 인프라 생성/업데이트
+
+```bash
+terraform apply
+```
+
+### 5. SSH 접속
+
+```bash
+# Output에서 SSH 명령어 확인
+terraform output ssh_command
+
+# 또는 직접 접속
+ssh -i ~/.ssh/gaon_ver2.key ubuntu@<BACKEND_IP>
+```
+
+### 6. 인프라 삭제
+
+```bash
+terraform destroy
+```
+
+## 설정 변경
+
+`terraform.tfvars` 파일에서 설정을 변경할 수 있습니다:
+
+```hcl
+region       = "asia-northeast3"
+zone         = "asia-northeast3-a"
+machine_type = "e2-medium"
+disk_size    = 30
+```
+
+## Outputs
+
+- `backend_ip`: 백엔드 서버 공인 IP
+- `ssh_command`: SSH 접속 명령어
+- `bucket_name`: GCS 버킷 이름
+- `artifact_registry`: Artifact Registry 이름
+- `rag_processor_url`: RAG 프로세서 URL
+- `toc_processor_url`: TOC 프로세서 URL
+
+## 파일 구조
+
+```
+terraform/
+├── main.tf              # VM, 방화벽, SSH 키
+├── gcp_resources.tf     # Storage, Functions, Pub/Sub
+├── variables.tf         # 변수 정의
+├── terraform.tfvars     # 변수 값
+├── startup-backend.sh   # VM 초기 설정
+├── README.md           # 이 파일
+└── IMPORT.md           # Import 가이드
+```
+
+## 주의사항
+
+- Cloud Functions 소스 코드는 별도 배포 필요
+- Terraform은 인프라 구조만 관리
+- 민감정보는 `.env` 파일로 관리 (Git 제외)

--- a/terraform/gcp_resources.tf
+++ b/terraform/gcp_resources.tf
@@ -1,0 +1,162 @@
+# GCP Storage Bucket
+resource "google_storage_bucket" "gaon_data" {
+  name          = "gaon-cloud-data"
+  location      = "ASIA"
+  force_destroy = false  # 버킷에 파일이 있으면 삭제 불가
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true  # 파일 버전 관리 활성화
+  }
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true  # terraform destroy 시 삭제 방지
+  }
+}
+
+# Artifact Registry - Docker
+resource "google_artifact_registry_repository" "gaon_docker" {
+  location      = "asia-northeast3"
+  repository_id = "gaon-docker-hub"
+  description   = "GAON Docker images repository"
+  format        = "DOCKER"
+
+  lifecycle {
+    prevent_destroy = true  # 삭제 방지
+  }
+}
+
+# Pub/Sub Topic for Cloud Functions
+resource "google_pubsub_topic" "gcs_rag_notifications" {
+  name = "gcs-rag-notifications"
+}
+
+# Cloud Storage notification to Pub/Sub
+resource "google_storage_notification" "rag_notification" {
+  bucket         = google_storage_bucket.gaon_data.name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.gcs_rag_notifications.id
+  event_types    = ["OBJECT_FINALIZE"]
+
+  depends_on = [google_pubsub_topic_iam_member.gcs_publisher]
+}
+
+# IAM for GCS to publish to Pub/Sub
+data "google_storage_project_service_account" "gcs_account" {
+}
+
+resource "google_pubsub_topic_iam_member" "gcs_publisher" {
+  topic  = google_pubsub_topic.gcs_rag_notifications.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+}
+
+# Cloud Function - RAG Processor (나중에 추가)
+# resource "google_cloudfunctions2_function" "rag_processor" {
+#   name        = "rag-processor"
+#   location    = "asia-northeast3"
+#   description = "RAG file processor triggered by GCS uploads"
+
+#   build_config {
+#     runtime     = "python311"
+#     entry_point = "rag_file_processor"
+#     source {
+#       storage_source {
+#         bucket = "gcf-v2-sources-${data.google_project.project.number}-asia-northeast3"
+#         object = "rag-processor/function-source.zip"
+#       }
+#     }
+#   }
+
+#   service_config {
+#     max_instance_count = 10
+#     available_memory   = "512M"
+#     timeout_seconds    = 540
+#     environment_variables = {
+#       GCP_PROJECT_ID = local.project_id
+#       BUCKET_NAME    = google_storage_bucket.gaon_data.name
+#     }
+#   }
+
+#   event_trigger {
+#     trigger_region        = "asia-northeast3"
+#     event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+#     pubsub_topic          = google_pubsub_topic.gcs_rag_notifications.id
+#     retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
+#     service_account_email = data.google_compute_default_service_account.default.email
+#   }
+# }
+
+# Cloud Function - TOC PDF Processor (나중에 추가)
+# resource "google_cloudfunctions2_function" "toc_pdf_processor" {
+#   name        = "toc-pdf-processor"
+#   location    = "asia-northeast3"
+#   description = "TOC PDF processor"
+
+#   build_config {
+#     runtime     = "python311"
+#     entry_point = "toc_pdf_processor"
+#     source {
+#       storage_source {
+#         bucket = "gcf-v2-sources-${data.google_project.project.number}-asia-northeast3"
+#         object = "toc-pdf-processor/function-source.zip"
+#       }
+#     }
+#   }
+
+#   service_config {
+#     max_instance_count = 10
+#     available_memory   = "512M"
+#     timeout_seconds    = 540
+#     environment_variables = {
+#       GCP_PROJECT_ID = local.project_id
+#     }
+#   }
+
+#   event_trigger {
+#     trigger_region        = "asia-northeast3"
+#     event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+#     pubsub_topic          = google_pubsub_topic.gcs_rag_notifications.id
+#     retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
+#     service_account_email = data.google_compute_default_service_account.default.email
+#   }
+# }
+
+# Data sources
+data "google_project" "project" {
+  project_id = local.project_id
+}
+
+# data "google_compute_default_service_account" "default" {
+# }
+
+# Outputs
+output "bucket_name" {
+  value       = google_storage_bucket.gaon_data.name
+  description = "GCS bucket name"
+}
+
+output "artifact_registry" {
+  value       = google_artifact_registry_repository.gaon_docker.name
+  description = "Artifact Registry repository name"
+}
+
+# output "rag_processor_url" {
+#   value       = google_cloudfunctions2_function.rag_processor.service_config[0].uri
+#   description = "RAG processor function URL"
+# }
+
+# output "toc_processor_url" {
+#   value       = google_cloudfunctions2_function.toc_pdf_processor.service_config[0].uri
+#   description = "TOC processor function URL"
+# }

--- a/terraform/get_db_config.py
+++ b/terraform/get_db_config.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import sys
+sys.path.insert(0, '../backend')
+from app.core.config import settings
+
+print(f'export TF_VAR_db_user="{settings.db_user}"')
+print(f'export TF_VAR_db_password="{settings.db_password}"')
+print(f'export TF_VAR_db_name="{settings.db_name}"')

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,149 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# GCP 서비스 계정 키에서 project_id 읽기
+locals {
+  gcp_credentials = jsondecode(file("${path.module}/../backend/gcp_service_account_key.json"))
+  project_id      = local.gcp_credentials.project_id
+}
+
+provider "google" {
+  credentials = file("${path.module}/../backend/gcp_service_account_key.json")
+  project     = local.project_id
+  region      = var.region
+}
+
+# SSH 키 생성
+resource "tls_private_key" "gaon_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_file" "private_key" {
+  content         = tls_private_key.gaon_key.private_key_pem
+  filename        = pathexpand("~/.ssh/gaon_ver2.key")
+  file_permission = "0600"
+}
+
+resource "local_file" "public_key" {
+  content         = tls_private_key.gaon_key.public_key_openssh
+  filename        = pathexpand("~/.ssh/gaon_ver2.key.pub")
+  file_permission = "0644"
+}
+
+# 방화벽 규칙 - HTTP
+resource "google_compute_firewall" "gaon_http" {
+  name    = "gaon-allow-http"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gaon-backend"]
+}
+
+# 방화벽 규칙 - HTTPS
+resource "google_compute_firewall" "gaon_https" {
+  name    = "gaon-allow-https"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gaon-backend"]
+}
+
+# 방화벽 규칙 - Backend API
+resource "google_compute_firewall" "gaon_backend_api" {
+  name    = "gaon-allow-backend-api"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8000"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gaon-backend"]
+}
+
+# 방화벽 규칙 - SSH
+resource "google_compute_firewall" "gaon_ssh" {
+  name    = "gaon-allow-ssh"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gaon-backend"]
+}
+
+# Backend VM
+resource "google_compute_instance" "gaon_backend" {
+  name         = "gaon-backend-server"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  tags = ["gaon-backend"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = var.disk_size
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${tls_private_key.gaon_key.public_key_openssh}"
+  }
+
+  metadata_startup_script = templatefile("${path.module}/startup-backend.sh", {
+    db_user     = var.db_user
+    db_password = var.db_password
+    db_name     = var.db_name
+  })
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+}
+
+output "backend_ip" {
+  value       = google_compute_instance.gaon_backend.network_interface[0].access_config[0].nat_ip
+  description = "Backend server public IP"
+}
+
+output "ssh_command" {
+  value       = "ssh -i ~/.ssh/gaon_ver2.key ubuntu@${google_compute_instance.gaon_backend.network_interface[0].access_config[0].nat_ip}"
+  description = "SSH command to connect to backend server"
+}

--- a/terraform/startup-backend.sh
+++ b/terraform/startup-backend.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Starting GAON server setup..."
+
+# 시스템 업데이트
+apt-get update
+apt-get upgrade -y
+
+# Docker 설치
+apt-get install -y ca-certificates curl gnupg lsb-release
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Docker 서비스 시작
+systemctl start docker
+systemctl enable docker
+
+# ubuntu 사용자를 docker 그룹에 추가
+usermod -aG docker ubuntu
+
+# GCP 인증 설정
+gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+# 프로젝트 디렉토리 생성
+mkdir -p /home/ubuntu/gaon
+cd /home/ubuntu/gaon
+
+# .env 파일 생성
+cat > .env << EOF
+DB_USER=${db_user}
+DB_PASSWORD=${db_password}
+DB_NAME=${db_name}
+EOF
+
+# docker-compose.prod.yml 다운로드 (GitHub에서)
+curl -o docker-compose.prod.yml https://raw.githubusercontent.com/HyunJunSon/GAON/main/docker-compose.prod.yml
+
+# nginx 설정 다운로드
+curl -o nginx.conf https://raw.githubusercontent.com/HyunJunSon/GAON/main/nginx.conf
+
+# Docker 이미지 pull 및 실행
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+
+# 권한 설정
+chown -R ubuntu:ubuntu /home/ubuntu/gaon
+
+echo "✅ Setup completed successfully!"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,41 @@
+variable "region" {
+  description = "GCP Region"
+  type        = string
+  default     = "asia-northeast3"
+}
+
+variable "zone" {
+  description = "GCP Zone"
+  type        = string
+  default     = "asia-northeast3-a"
+}
+
+variable "machine_type" {
+  description = "Backend VM machine type"
+  type        = string
+  default     = "e2-medium"
+}
+
+variable "disk_size" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 30
+}
+
+variable "db_user" {
+  description = "PostgreSQL username"
+  type        = string
+  default     = "gaon_admin"
+}
+
+variable "db_password" {
+  description = "PostgreSQL password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  default     = "gaon_db"
+}


### PR DESCRIPTION
## 🚀 변경 사항

### 인프라 구성 (Terraform)
- **Compute Engine**: e2-medium VM 인스턴스 생성 (gaon-backend-server)
- **방화벽 규칙**: HTTP(80), HTTPS(443), Backend API(8000), SSH(22)
- **Cloud Storage**: gaon-cloud-data 버킷 (버전 관리 활성화, 삭제 방지)
- **Artifact Registry**: gaon-docker-hub (Docker 이미지 저장소)
- **Pub/Sub**: gcs-rag-notifications (파일 업로드 알림)
- **SSH 키**: Terraform으로 자동 생성 및 관리

### 서버 마이그레이션
- OCI 서버 → GCP e2-medium VM 마이그레이션 완료
- PostgreSQL 데이터베이스 백업 및 복원 (59MB)
- Docker Compose로 전체 스택 배포
  - PostgreSQL (pgvector/pg17)
  - Backend (FastAPI)
  - Frontend (React)
  - Nginx (리버스 프록시)

### SSL 인증서
- Let's Encrypt SSL 인증서 설정
- 도메인: xn--o39a190c.site (가온.site)
- HTTP → HTTPS 자동 리다이렉트
- 인증서 만료일: 2026-02-21 (90일 자동 갱신)

### 보안
- 민감정보 보호를 위한 .gitignore 추가
  - terraform.tfstate, *.tfvars
  - GCP service account key
  - BFG report
- SSH 키 자동 생성 및 권한 관리

## ✅ 테스트 완료
- [x] GCP VM 정상 동작 확인 (CPU 6%, 메모리 25% 사용)
- [x] HTTPS 인증서 정상 작동
- [x] 모든 Docker 컨테이너 정상 실행
- [x] 데이터베이스 마이그레이션 완료
- [x] DNS 설정 확인 (34.64.199.47)
- [x] 백엔드 API 정상 응답 (version 1.0.2)

## 📊 서버 상태
- **CPU**: 6% 사용 (매우 안정적)
- **메모리**: 975MB / 3.8GB (25%)
- **디스크**: 16GB / 29GB (55%)
- **컨테이너별 리소스**:
  - Backend: 577.8MB (14.77%)
  - PostgreSQL: 92.9MB (2.37%)
  - Frontend: 90.6MB (2.31%)
  - Nginx: 4.8MB (0.12%)

## 📝 관련 이슈
- 서버 인프라 현대화
- IaC(Infrastructure as Code) 도입
- 보안 강화 (SSL, 방화벽)